### PR TITLE
Conversion of __version__ from unicode to python string. See issue #9.

### DIFF
--- a/phconvert/hdf5.py
+++ b/phconvert/hdf5.py
@@ -38,7 +38,7 @@ from .metadata import (official_fields_specs, root_attributes,
 from ._version import get_versions
 
 
-__version__ = get_versions()['version']
+__version__ = str(get_versions()['version'])
 
 # Empty description string (workaround for h5labview)
 _EMPTY = ' '


### PR DESCRIPTION
Returned `__version__ `string is unicode and not converted since it fails `isinstance(obj, str)`test. Python `str` function ensures that `__version__` is of proper type.