### PR TITLE
Implement Photon-HDF5 version 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
     - "2.7"
     - "3.4"
     - "3.5"
+    - "3.6"
 
 before_install:
     - echo $PATH

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,11 @@ environment:
       PYTHON_ARCH: "64"
       MINICONDA: C:\Miniconda35-x64
 
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "64"
+      MINICONDA: C:\Miniconda36-x64
+
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %MINICONDA%"
 

--- a/notebooks/Convert us-ALEX SM files to Photon-HDF5.ipynb
+++ b/notebooks/Convert us-ALEX SM files to Photon-HDF5.ipynb
@@ -339,7 +339,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -350,7 +350,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -361,7 +361,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [

--- a/notebooks/Writing Photon-HDF5 files.ipynb
+++ b/notebooks/Writing Photon-HDF5 files.ipynb
@@ -143,13 +143,14 @@
    "source": [
     "setup = dict(\n",
     "    ## Mandatory fields\n",
-    "    num_pixels = 2,               # using 2 detectors\n",
-    "    num_spots = 1,                # a single confoca excitation\n",
-    "    num_spectral_ch = 2,          # donor and acceptor detection \n",
-    "    num_polarization_ch = 1,      # no polarization selection \n",
-    "    num_split_ch = 1,             # no beam splitter\n",
-    "    modulated_excitation = False, # CW excitation, no modulation \n",
-    "    lifetime = False,             # no TCSPC in detection\n",
+    "    num_pixels = 2,                   # using 2 detectors\n",
+    "    num_spots = 1,                    # a single confoca excitation\n",
+    "    num_spectral_ch = 2,              # donor and acceptor detection \n",
+    "    num_polarization_ch = 1,          # no polarization selection \n",
+    "    num_split_ch = 1,                 # no beam splitter\n",
+    "    modulated_excitation = False,     # CW excitation, no modulation \n",
+    "    excitation_alternated = [False],  # CW excitation, no modulation \n",
+    "    lifetime = False,                 # no TCSPC in detection\n",
     "    \n",
     "    ## Optional fields\n",
     "    excitation_wavelengths = [532e-9],         # List of excitation wavelenghts\n",
@@ -338,8 +339,9 @@
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },
@@ -353,7 +355,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,

--- a/phconvert/hdf5.py
+++ b/phconvert/hdf5.py
@@ -569,7 +569,8 @@ def _sorted_photon_data_tables(h5file):
     ph_datas = [n for n in h5file.root._f_iter_nodes()
                 if n._v_name.startswith(prefix)]
 
-    ph_datas.sort(key=lambda x: x._v_name[len(prefix):])
+    if len(ph_datas) > 1:
+        ph_datas.sort(key=lambda x: int(x._v_name[len(prefix):]))
     return ph_datas
 
 def _sorted_photon_data(data_dict):
@@ -581,8 +582,7 @@ def _sorted_photon_data(data_dict):
     prefix = 'photon_data'
     keys = [k for k in data_dict.keys() if k.startswith(prefix)]
     if len(keys) > 1:
-        sorted_channels = sorted([int(k[len(prefix):]) for k in keys])
-        keys = ['%s%d' % (prefix, ch) for ch in sorted_channels]
+        keys.sort(key=lambda x: int(x[len(prefix):]))
     return keys
 
 def photon_data_mapping(h5file, name='timestamps'):

--- a/phconvert/hdf5.py
+++ b/phconvert/hdf5.py
@@ -137,6 +137,7 @@ def _h5_write_array(group, name, obj, descr=None, chunked=False, h5file=None):
         if isinstance(obj, str):
             obj = obj.encode()
 
+    ## TODO: remove node if already present
     save(group, name, obj=obj)
     # Set title through property access to work around pytable issue
     # under python 3 (https://github.com/PyTables/PyTables/issues/469)
@@ -287,7 +288,7 @@ def save_photon_hdf5(data_dict,
             If None and h5file is also None, the file name is taken from
             ``data_dict['_filename']`` with extension changed to '.hdf5'.
         h5file (pytables.File or None): an already open and writable
-            HDF5 file to use as contained. Use if you want to reuse an HDF5
+            HDF5 file to use as container. Use if you want to reuse an HDF5
             file where you have already have stored photon_data arrays.
         user_descr (dict or None): dictionary of descriptions (strings) for
             user-defined fields. The keys must be strings representing

--- a/phconvert/hdf5.py
+++ b/phconvert/hdf5.py
@@ -798,7 +798,7 @@ def _assert_has_field(name, group, msg=None, msg_add=None, mandatory=True,
     return _assert_valid(name in group, msg, mandatory, norepeat, pool)
 
 
-def _asser_valid_detectors(h5file):
+def _assert_valid_detectors(h5file):
     det_cnts = {}
     for ph_data in _sorted_photon_data_tables(h5file):
         vals, counts = np.unique(ph_data.detectors[:], return_counts=True)
@@ -894,7 +894,7 @@ def _assert_setup(h5file, warnings=True, strict=True, verbose=False):
             _assert_has_field(name, h5file.root.setup, mandatory=False,
                               verbose=verbose)
         if 'detectors' in h5file.root.setup:
-            _asser_valid_detectors(h5file)
+            _assert_valid_detectors(h5file)
 
 def _assert_identity(h5file, warnings=True, strict=True, verbose=False):
     """Assert that identity group exists and contains the mandatory fields.

--- a/phconvert/hdf5.py
+++ b/phconvert/hdf5.py
@@ -809,7 +809,7 @@ def _asser_valid_detectors(h5file):
     sort_idx = det_counts_a[:, 0].argsort()
     det_counts_a = det_counts_a[sort_idx]
 
-    detectors = h5file.setup.detectors
+    detectors = h5file.root.setup.detectors
     dets_ids = detectors.id.read()
     m = 'detectors/id length is no equal to the number of unique detetors.'
     _assert_valid(len(det_cnts) == len(dets_ids), msg=m)

--- a/phconvert/hdf5.py
+++ b/phconvert/hdf5.py
@@ -203,14 +203,6 @@ def _save_photon_hdf5_dict(group, data_dict, fields_descr, prefix_list=None,
                             chunked=item['is_phdata'], h5file=group._v_file)
 
 
-def _link_measurement_specs(h5file):
-    if 'setup' in h5file.root and 'measurement_specs' in h5file.root.setup:
-        link_kws = dict(name='measurement_specs',
-                        target='/setup/measurement_specs')
-        for ph_data in _sorted_photon_data_tables(h5file):
-            h5file.create_hard_link(ph_data, **link_kws)
-
-
 def save_photon_hdf5(data_dict,
                      h5_fname = None,
                      user_descr = None,
@@ -346,7 +338,6 @@ def save_photon_hdf5(data_dict,
         fields_descr.update(user_descr)
     _save_photon_hdf5_dict(h5file.root, data_dict,
                            fields_descr=fields_descr, debug=debug)
-    _link_measurement_specs(h5file)
     h5file.flush()
 
     ## Validation
@@ -896,8 +887,7 @@ def _assert_valid_fields(h5file, strict_description=True, verbose=False):
         #msg = 'TITLE attribute for "%s" is not a binary string.' % pathname
         #_assert_valid(isinstance(title, bytes), msg, strict=strict_description)
 
-        if (metaname.startswith('/photon_data/measurement_specs') or
-                pathname.endswith('/user') or '/user/' in pathname):
+        if pathname.endswith('/user') or '/user/' in pathname:
             pass
         else:
             # Check field names
@@ -941,14 +931,14 @@ def _check_photon_data_tables(ph_data, setup, norepeat=False, pool=None,
     if 'measurement_specs' not in ph_data:
         if not skip_measurement_specs:
             # Called to print a warning
-            _assert_has_field('measurement_specs', setup, mandatory=False,
+            _assert_has_field('measurement_specs', ph_data, mandatory=False,
                               verbose=verbose, norepeat=norepeat, pool=pool)
         return
 
     all_meas_types = ['smFRET', 'smFRET-usALEX', 'smFRET-usALEX-3c',
                       'smFRET-nsALEX', 'generic']
 
-    meas_specs = setup.measurement_specs
+    meas_specs = ph_data.measurement_specs
     msg = 'Missing "measurement_type" in "%s".' % meas_specs._v_pathname
     _assert_has_field('measurement_type', meas_specs, msg, verbose=verbose)
 

--- a/phconvert/hdf5.py
+++ b/phconvert/hdf5.py
@@ -933,6 +933,11 @@ def _check_photon_data_tables(ph_data, norepeat=False, pool=None,
 
     spectral_meas_types = ['smFRET', 'smFRET-usALEX', 'smFRET-usALEX-3c',
                            'smFRET-nsALEX']
+    other_meas_types = ['cw_split', 'cw_polarization',
+                        'cw_split_polarization',
+                        'tcspc_split', 'tcspc_polarization',
+                        'tcspc_split_polarization']
+    all_meas_types = spectral_meas_types + other_meas_types
     meas_specs = ph_data.measurement_specs
     msg = 'Missing "measurement_type" in "%s".' % meas_specs._v_pathname
     _assert_has_field('measurement_type', meas_specs, msg, verbose=verbose)
@@ -940,22 +945,43 @@ def _check_photon_data_tables(ph_data, norepeat=False, pool=None,
     meas_type = meas_specs.measurement_type.read().decode()
     if verbose:
         print('* Measurement type: "%s"' % meas_type)
-    _assert_valid(meas_type in spectral_meas_types,
-                  msg='Unkwnown measurement type "%s"' % meas_type)
+    _assert_valid(meas_type in all_meas_types,
+                  msg='Unknown measurement type "%s"' % meas_type)
 
     # At this point we have a valid measurement_type
-    # Any missing field will raise an error.
+    # We will check (and raise an error) for any missing field.
     msg = '\nThis field is mandatory for "%s" data.' % meas_type
     kwargs = dict(msg_add=msg, verbose=verbose)
-    _assert_has_field('spectral_ch1', meas_specs.detectors_specs, **kwargs)
-    _assert_has_field('spectral_ch2', meas_specs.detectors_specs, **kwargs)
+    det_specs = meas_specs.detectors_specs
 
+    # Check for spectral channels
+    if meas_type in spectral_meas_types:
+        _assert_has_field('spectral_ch1', det_specs, **kwargs)
+        _assert_has_field('spectral_ch2', det_specs, **kwargs)
+    if meas_type == 'smFRET-usALEX-3c':
+        _assert_has_field('spectral_ch3', det_specs, **kwargs)
+
+    # Check for split/polarization channels
+    for feature in ('split', 'polarization'):
+        if feature in meas_type:
+            _assert_has_field('%s_ch1' % feature, det_specs, **kwargs)
+            _assert_has_field('%s_ch2' % feature, det_specs, **kwargs)
+
+    # us-ALEX fields
     if meas_type in ['smFRET-usALEX', 'smFRET-usALEX-3c']:
         _assert_has_field('alex_period', meas_specs, **kwargs)
 
+    # ns-ALEX / PIE fields
     if meas_type == 'smFRET-nsALEX':
         _assert_has_field('laser_repetition_rate', meas_specs, **kwargs)
+
+    # TCSPC fields
+    if meas_type == 'smFRET-nsALEX' or 'tcspc' in meas_type:
+        _assert_has_field('laser_repetition_rate', meas_specs, **kwargs)
         _assert_has_field('nanotimes', ph_data, **kwargs)
+        # TODO: implement valid case when nanotimes_specs is not present
+        #       but TCSPC data is stored in /setup/detectorN
+        #       See https://github.com/Photon-HDF5/photon-hdf5/issues/36
         _assert_has_field('nanotimes_specs', ph_data, **kwargs)
         for name in ['tcspc_unit', 'tcspc_num_bins']:
             _assert_has_field(name, ph_data.nanotimes_specs, **kwargs)

--- a/phconvert/loader.py
+++ b/phconvert/loader.py
@@ -59,7 +59,13 @@ def usalex_sm(
                                    spectral_ch2 = np.atleast_1d(acceptor))),
     )
 
+    detectors_group = dict(
+        id=[0, 1],
+        counts=[(detectors == ch).sum() for ch in sorted([donor, acceptor])]
+    )
+
     setup = dict(
+        detectors = detectors_group,
         num_pixels = 2,
         num_spots = 1,
         num_spectral_ch = 2,

--- a/phconvert/loader.py
+++ b/phconvert/loader.py
@@ -59,13 +59,7 @@ def usalex_sm(
                                    spectral_ch2 = np.atleast_1d(acceptor))),
     )
 
-    detectors_group = dict(
-        id=[0, 1],
-        counts=[(detectors == ch).sum() for ch in sorted([donor, acceptor])]
-    )
-
     setup = dict(
-        detectors = detectors_group,
         num_pixels = 2,
         num_spots = 1,
         num_spectral_ch = 2,

--- a/phconvert/loader.py
+++ b/phconvert/loader.py
@@ -49,7 +49,9 @@ def usalex_sm(
         timestamps = timestamps,
         timestamps_specs = dict(timestamps_unit=12.5e-9),
         detectors = detectors,
+    )
 
+    setup = dict(
         measurement_specs = dict(
             measurement_type = 'smFRET-usALEX',
             alex_period = alex_period,
@@ -57,10 +59,7 @@ def usalex_sm(
             alex_excitation_period1 = alex_period_donor,
             alex_excitation_period2 = alex_period_acceptor,
             detectors_specs = dict(spectral_ch1 = np.atleast_1d(donor),
-                                   spectral_ch2 = np.atleast_1d(acceptor)))
-    )
-
-    setup = dict(
+                                   spectral_ch2 = np.atleast_1d(acceptor))),
         num_pixels = 2,
         num_spots = 1,
         num_spectral_ch = 2,
@@ -154,17 +153,16 @@ def nsalex_bh(filename_spc,
             tcspc_unit = tcspc_unit,
             tcspc_range = tcspc_range,
             tcspc_num_bins = tcspc_num_bins),
+    )
 
+    setup = dict(
         measurement_specs = dict(
             measurement_type = 'smFRET-nsALEX',
             laser_repetition_rate = 1 / timestamps_unit,
             alex_excitation_period1 = alex_period_donor,
             alex_excitation_period2 = alex_period_acceptor,
             detectors_specs = dict(spectral_ch1 = np.atleast_1d(donor),
-                                   spectral_ch2 = np.atleast_1d(acceptor)))
-    )
-
-    setup = dict(
+                                   spectral_ch2 = np.atleast_1d(acceptor))),
         num_pixels = 2,
         num_spots = 1,
         num_spectral_ch = 2,
@@ -239,17 +237,16 @@ def nsalex_ht3(filename,
             tcspc_unit = tcspc_unit,
             tcspc_range = tcspc_range,
             tcspc_num_bins = tcspc_num_bins),
+    )
 
+    setup = dict(
         measurement_specs = dict(
             measurement_type = 'smFRET-nsALEX',
             laser_repetition_rate = laser_repetition_rate,
             alex_excitation_period1 = alex_period_donor,
             alex_excitation_period2 = alex_period_acceptor,
             detectors_specs = dict(spectral_ch1 = np.atleast_1d(donor),
-                                   spectral_ch2 = np.atleast_1d(acceptor)))
-    )
-
-    setup = dict(
+                                   spectral_ch2 = np.atleast_1d(acceptor))),
         num_pixels = 2,
         num_spots = 1,
         num_spectral_ch = 2,

--- a/phconvert/loader.py
+++ b/phconvert/loader.py
@@ -49,9 +49,6 @@ def usalex_sm(
         timestamps = timestamps,
         timestamps_specs = dict(timestamps_unit=12.5e-9),
         detectors = detectors,
-    )
-
-    setup = dict(
         measurement_specs = dict(
             measurement_type = 'smFRET-usALEX',
             alex_period = alex_period,
@@ -60,6 +57,9 @@ def usalex_sm(
             alex_excitation_period2 = alex_period_acceptor,
             detectors_specs = dict(spectral_ch1 = np.atleast_1d(donor),
                                    spectral_ch2 = np.atleast_1d(acceptor))),
+    )
+
+    setup = dict(
         num_pixels = 2,
         num_spots = 1,
         num_spectral_ch = 2,
@@ -153,9 +153,6 @@ def nsalex_bh(filename_spc,
             tcspc_unit = tcspc_unit,
             tcspc_range = tcspc_range,
             tcspc_num_bins = tcspc_num_bins),
-    )
-
-    setup = dict(
         measurement_specs = dict(
             measurement_type = 'smFRET-nsALEX',
             laser_repetition_rate = 1 / timestamps_unit,
@@ -163,6 +160,9 @@ def nsalex_bh(filename_spc,
             alex_excitation_period2 = alex_period_acceptor,
             detectors_specs = dict(spectral_ch1 = np.atleast_1d(donor),
                                    spectral_ch2 = np.atleast_1d(acceptor))),
+    )
+
+    setup = dict(
         num_pixels = 2,
         num_spots = 1,
         num_spectral_ch = 2,
@@ -237,9 +237,6 @@ def nsalex_ht3(filename,
             tcspc_unit = tcspc_unit,
             tcspc_range = tcspc_range,
             tcspc_num_bins = tcspc_num_bins),
-    )
-
-    setup = dict(
         measurement_specs = dict(
             measurement_type = 'smFRET-nsALEX',
             laser_repetition_rate = laser_repetition_rate,
@@ -247,6 +244,9 @@ def nsalex_ht3(filename,
             alex_excitation_period2 = alex_period_acceptor,
             detectors_specs = dict(spectral_ch1 = np.atleast_1d(donor),
                                    spectral_ch2 = np.atleast_1d(acceptor))),
+    )
+
+    setup = dict(
         num_pixels = 2,
         num_spots = 1,
         num_spectral_ch = 2,

--- a/phconvert/loader.py
+++ b/phconvert/loader.py
@@ -70,7 +70,8 @@ def usalex_sm(
         lifetime = False,
         excitation_wavelengths = excitation_wavelengths,
         excitation_cw = [True, True],
-        detection_wavelengths = detection_wavelengths)
+        detection_wavelengths = detection_wavelengths,
+        excitation_alternated=[True, True])
 
     provenance = dict(filename=filename, software=software)
     acquisition_duration = (timestamps[-1] - timestamps[0]) * 12.5e-9
@@ -173,7 +174,8 @@ def nsalex_bh(filename_spc,
         lifetime = True,
         excitation_wavelengths = excitation_wavelengths,
         excitation_cw = [False, False],
-        detection_wavelengths = detection_wavelengths)
+        detection_wavelengths = detection_wavelengths,
+        excitation_alternated = [False, False])
 
     acquisition_duration = ((timestamps.max() - timestamps.min()) *
                             timestamps_unit)
@@ -257,7 +259,8 @@ def nsalex_ht3(filename,
         lifetime = True,
         excitation_wavelengths = excitation_wavelengths,
         excitation_cw = [False, False],
-        detection_wavelengths = detection_wavelengths)
+        detection_wavelengths = detection_wavelengths,
+        excitation_alternated = [False, False])
 
     data = dict(
         _filename=filename,

--- a/phconvert/metadata.py
+++ b/phconvert/metadata.py
@@ -13,7 +13,7 @@ import pkg_resources
 from collections import OrderedDict
 import json
 
-LATEST_FORMAT_VERSION = b'0.4'
+LATEST_FORMAT_VERSION = b'0.5.dev'
 
 _specs_file_fields = 'specs/photon-hdf5_specs.json'
 

--- a/phconvert/plotter.py
+++ b/phconvert/plotter.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 _green = 'g'
-_red  = 'r'
+_red = 'r'
 
 
 def alternation_hist(d, bins=None, ax=None, **kwargs):
@@ -17,8 +17,7 @@ def alternation_hist(d, bins=None, ax=None, **kwargs):
     modulated_excitation = d['setup']['modulated_excitation']
     assert modulated_excitation
 
-    measurement_type = d['photon_data']['measurement_specs']\
-                        ['measurement_type']
+    measurement_type = d['setup']['measurement_specs']['measurement_type']
 
     if measurement_type == 'smFRET-usALEX':
         plot_alternation = alternation_hist_usalex
@@ -46,21 +45,22 @@ def alternation_hist_usalex(d, bins=None, ax=None,
     ph_data = d['photon_data']
     ph_times_t = ph_data['timestamps']
     det_t = ph_data['detectors']
-    period = ph_data['measurement_specs']['alex_period']
+    meas_specs = d['setup']['measurement_specs']
+    period = meas_specs['alex_period']
 
-    det_specs = ph_data['measurement_specs']['detectors_specs']
-    d_ch =  det_specs['spectral_ch1']
-    a_ch =  det_specs['spectral_ch2']
+    det_specs = meas_specs['detectors_specs']
+    d_ch = det_specs['spectral_ch1']
+    a_ch = det_specs['spectral_ch2']
 
     d_em_t = (det_t == d_ch)
     a_em_t = (det_t == a_ch)
-    D_ON = ph_data['measurement_specs']['alex_excitation_period1']
-    A_ON = ph_data['measurement_specs']['alex_excitation_period2']
-    offset = ph_data['measurement_specs']['alex_offset']
+    D_ON = meas_specs['alex_excitation_period1']
+    A_ON = meas_specs['alex_excitation_period2']
+    offset = meas_specs['alex_offset']
     D_label = 'Donor: %d-%d' % (D_ON[0], D_ON[1])
     A_label = 'Accept: %d-%d' % (A_ON[0], A_ON[1])
 
-    hist_style_ = dict(bins=bins,  alpha=0.5, histtype='stepfilled', lw=1.3)
+    hist_style_ = dict(bins=bins, alpha=0.5, histtype='stepfilled', lw=1.3)
     hist_style_.update(hist_style)
 
     span_style_ = dict(alpha=0.1)
@@ -98,12 +98,13 @@ def alternation_hist_nsalex(d, bins=None, ax=None):
     if bins is None:
         bins = np.arange(ph_data['nanotimes_specs']['tcspc_num_bins'])
 
-    det_specs = ph_data['measurement_specs']['detectors_specs']
-    d_ch =  det_specs['spectral_ch1']
-    a_ch =  det_specs['spectral_ch2']
+    meas_specs = d['setup']['measurement_specs']
+    det_specs = meas_specs['detectors_specs']
+    d_ch = det_specs['spectral_ch1']
+    a_ch = det_specs['spectral_ch2']
 
-    D_ON = ph_data['measurement_specs']['alex_excitation_period1']
-    A_ON = ph_data['measurement_specs']['alex_excitation_period2']
+    D_ON = meas_specs['alex_excitation_period1']
+    A_ON = meas_specs['alex_excitation_period2']
 
     D_label = 'Donor: %d-%d' % (D_ON[0], D_ON[1])
     A_label = 'Accept: %d-%d' % (A_ON[0], A_ON[1])
@@ -112,9 +113,9 @@ def alternation_hist_nsalex(d, bins=None, ax=None):
     nanotimes_a = ph_data['nanotimes'][ph_data['detectors'] == a_ch]
 
     ax.hist(nanotimes_d, bins=bins, histtype='step', label=D_label, lw=1.2,
-             alpha=0.5, color=_green)
+            alpha=0.5, color=_green)
     ax.hist(nanotimes_a, bins=bins, histtype='step', label=A_label, lw=1.2,
-             alpha=0.5, color=_red)
+            alpha=0.5, color=_red)
     ax.set_xlabel('TCSPC nanotimes bins')
 
     ax.set_yscale('log')

--- a/phconvert/plotter.py
+++ b/phconvert/plotter.py
@@ -17,7 +17,7 @@ def alternation_hist(d, bins=None, ax=None, **kwargs):
     modulated_excitation = d['setup']['modulated_excitation']
     assert modulated_excitation
 
-    measurement_type = d['setup']['measurement_specs']['measurement_type']
+    measurement_type = d['photon_data']['measurement_specs']['measurement_type']
 
     if measurement_type == 'smFRET-usALEX':
         plot_alternation = alternation_hist_usalex
@@ -45,7 +45,7 @@ def alternation_hist_usalex(d, bins=None, ax=None,
     ph_data = d['photon_data']
     ph_times_t = ph_data['timestamps']
     det_t = ph_data['detectors']
-    meas_specs = d['setup']['measurement_specs']
+    meas_specs = ph_data['measurement_specs']
     period = meas_specs['alex_period']
 
     det_specs = meas_specs['detectors_specs']
@@ -98,7 +98,7 @@ def alternation_hist_nsalex(d, bins=None, ax=None):
     if bins is None:
         bins = np.arange(ph_data['nanotimes_specs']['tcspc_num_bins'])
 
-    meas_specs = d['setup']['measurement_specs']
+    meas_specs = ph_data['measurement_specs']
     det_specs = meas_specs['detectors_specs']
     d_ch = det_specs['spectral_ch1']
     a_ch = det_specs['spectral_ch2']

--- a/phconvert/pqreader.py
+++ b/phconvert/pqreader.py
@@ -362,10 +362,10 @@ def pt3_reader(filename):
         # Special header for imaging. How many of the following ImgHdr
         # array elements are actually present in the file is indicated by
         # ImgHdrSize above.
-        ImgHdr = np.fromfile(f, dtype='int32', count=ttmode['ImgHdrSize'])
+        ImgHdr = np.fromfile(f, dtype='int32', count=ttmode['ImgHdrSize'][0])
 
         # The remainings are all T3 records
-        t3records = np.fromfile(f, dtype='uint32', count=ttmode['nRecords'])
+        t3records = np.fromfile(f, dtype='uint32', count=ttmode['nRecords'][0])
 
         timestamps_unit = 1./ttmode['InpRate0']
         nanotimes_unit = 1e-9*hardware['Resolution']

--- a/phconvert/specs/photon-hdf5_specs.json
+++ b/phconvert/specs/photon-hdf5_specs.json
@@ -179,6 +179,42 @@
         "Power fraction detected by each \"beam-split\" channel (i.e. independent detection channels obtained through a non-polarizing beam splitter).",
         "array"
     ],
+    "/setup/detectors": [
+        "Metadata relative to each detector's pixel. Each field is an array with size equal to the number of the detectors.",
+        "group"
+    ],
+    "/setup/detectors/ids": [
+        "Array of original IDs assigned by the acquisition hardware to each detector.",
+        "array"
+    ],
+    "/setup/detectors/labels": [
+        "Array of labels (strings) describing each detector.",
+        "array"
+    ],
+    "/setup/detectors/counts": [
+        "Array of number photons detected by each detector.",
+        "array"
+    ],
+    "/setup/detectors/module": [
+        "Array of strings containing the module's name for each pixel.",
+        "array"
+    ],
+    "/setup/detectors/position": [
+        "2-D array of integers containing the X-Y coordinates of each pixel in the array.",
+        "array"
+    ],
+    "/setup/detectors/dcr": [
+        "Dark counts (cps) for each pixel.",
+        "array"
+    ],
+    "/setup/detectors/afterpulsing": [
+        "Afterpulsing probability for each pixel.",
+        "array"
+    ],
+    "/setup/detectors/spot": [
+        "Spot number where the pixel is used.",
+        "array"
+    ],
     "/identity": [
         "Information about the Photon-HDF5 data file.",
         "group"

--- a/phconvert/specs/photon-hdf5_specs.json
+++ b/phconvert/specs/photon-hdf5_specs.json
@@ -123,10 +123,6 @@
         "Pixel IDs for the second channel split through a non-polarizing beam splitter.",
         "array"
     ],
-    "/setup/measurement_specs/detectors_specs/labels": [
-        "User defined labels for each pixel IDs. In smFRET it is suggested to use \"donor\" and \"acceptor\" for the respective pixel IDs.",
-        "string"
-    ],
     "/setup/num_pixels": [
         "Total number of detector pixels.",
         "scalar"

--- a/phconvert/specs/photon-hdf5_specs.json
+++ b/phconvert/specs/photon-hdf5_specs.json
@@ -55,73 +55,73 @@
         "TCSPC full-scale range in seconds.",
         "scalar"
     ],
-    "/setup": [
-        "Information about the experimental setup.",
-        "group"
-    ],
-    "/setup/measurement_specs": [
+    "/photon_data/measurement_specs": [
         "Metadata necessary for interpretation of the particular type of measurement.",
         "group"
     ],
-    "/setup/measurement_specs/measurement_type": [
+    "/photon_data/measurement_specs/measurement_type": [
         "Name of the measurement the data represents.",
         "string"
     ],
-    "/setup/measurement_specs/alex_period": [
+    "/photon_data/measurement_specs/alex_period": [
         "Period of laser alternation in us-ALEX measurements in timestamps units (defined in timestamps_specs/).",
         "scalar"
     ],
-    "/setup/measurement_specs/laser_repetition_rate": [
+    "/photon_data/measurement_specs/laser_repetition_rate": [
         "Repetition rate of the pulsed excitation laser (in Hertz).",
         "scalar"
     ],
-    "/setup/measurement_specs/alex_offset": [
+    "/photon_data/measurement_specs/alex_offset": [
         "Time offset (in timestamps unit) to apply to timestamps to obtain a properly aligned alternation histogram.",
         "scalar"
     ],
-    "/setup/measurement_specs/alex_excitation_period1": [
+    "/photon_data/measurement_specs/alex_excitation_period1": [
         "Values pair (start-stop range, in timestamps units) identifying photons in the excitation period of wavelength 1 (the shortest).",
         "array"
     ],
-    "/setup/measurement_specs/alex_excitation_period2": [
+    "/photon_data/measurement_specs/alex_excitation_period2": [
         "Values pair (start-stop range, in timestamps units) identifying photons in the excitation period of wavelength 2.",
         "array"
     ],
-    "/setup/measurement_specs/detectors_specs": [
+    "/photon_data/measurement_specs/detectors_specs": [
         "Mapping between the pixel IDs and the detection channels.",
         "group"
     ],
-    "/setup/measurement_specs/detectors_specs/spectral_ch1": [
+    "/photon_data/measurement_specs/detectors_specs/spectral_ch1": [
         "Pixel IDs for the first spectral channel (i.e. donor in a 2-color smFRET measurement).",
         "array"
     ],
-    "/setup/measurement_specs/detectors_specs/spectral_ch2": [
+    "/photon_data/measurement_specs/detectors_specs/spectral_ch2": [
         "Pixel IDs for the second spectral channel (i.e. acceptor in a 2-color smFRET measurement).",
         "array"
     ],
-    "/setup/measurement_specs/detectors_specs/spectral_ch3": [
+    "/photon_data/measurement_specs/detectors_specs/spectral_ch3": [
         "Pixel IDs for the third spectral detection channel.",
         "array"
     ],
-    "/setup/measurement_specs/detectors_specs/spectral_ch4": [
+    "/photon_data/measurement_specs/detectors_specs/spectral_ch4": [
         "Pixel IDs for the fourth spectral detection channel.",
         "array"
     ],
-    "/setup/measurement_specs/detectors_specs/polarization_ch1": [
+    "/photon_data/measurement_specs/detectors_specs/polarization_ch1": [
         "Pixel IDs for the first polarization channel.",
         "array"
     ],
-    "/setup/measurement_specs/detectors_specs/polarization_ch2": [
+    "/photon_data/measurement_specs/detectors_specs/polarization_ch2": [
         "Pixel IDs for the second polarization channel.",
         "array"
     ],
-    "/setup/measurement_specs/detectors_specs/split_ch1": [
+    "/photon_data/measurement_specs/detectors_specs/split_ch1": [
         "Pixel IDs for the first channel split through a non-polarizing beam splitter.",
         "array"
     ],
-    "/setup/measurement_specs/detectors_specs/split_ch2": [
+    "/photon_data/measurement_specs/detectors_specs/split_ch2": [
         "Pixel IDs for the second channel split through a non-polarizing beam splitter.",
         "array"
+    ],    
+    "/setup": [
+        "Information about the experimental setup.",
+        "group"
     ],
     "/setup/num_pixels": [
         "Total number of detector pixels.",

--- a/phconvert/specs/photon-hdf5_specs.json
+++ b/phconvert/specs/photon-hdf5_specs.json
@@ -144,7 +144,7 @@
         "scalar"
     ],
     "/setup/excitation_alternated": [
-        "New in version 0.5. Indicates whether each excitation source is alternated (True, or 1) or not alternated (False, or 0)."
+        "New in version 0.5. Indicates whether each excitation source is alternated (True, or 1) or not alternated (False, or 0).",
         "array"
     ],
     "/setup/lifetime": [

--- a/phconvert/specs/photon-hdf5_specs.json
+++ b/phconvert/specs/photon-hdf5_specs.json
@@ -215,15 +215,11 @@
         "Spot number where the pixel is used.",
         "array"
     ],
-    "/setup/detectors/nanotimes_specs": [
-        "TCSPC specifications for each pixel.",
-        "group"
-    ],
-    "/setup/detectors/nanotimes_specs/tcspc_units": [
+    "/setup/detectors/tcspc_units": [
         "TCSPC bin size in seconds (i.e. nanotimes units) for each pixel.",
         "array"
     ],
-    "/setup/detectors/nanotimes_specs/tcspc_num_bins": [
+    "/setup/detectors/tcspc_num_bins": [
         "Number of TCSPC bins for each pixel.",
         "array"
     ],

--- a/phconvert/specs/photon-hdf5_specs.json
+++ b/phconvert/specs/photon-hdf5_specs.json
@@ -55,69 +55,77 @@
         "TCSPC full-scale range in seconds.",
         "scalar"
     ],
-    "/photon_data/measurement_specs": [
-        "Metadata necessary for interpretation of the particular type of measurement.",
-        "group"
-    ],
-    "/photon_data/measurement_specs/measurement_type": [
-        "Name of the measurement the data represents.",
-        "string"
-    ],
-    "/photon_data/measurement_specs/alex_period": [
-        "Period of laser alternation in us-ALEX measurements in timestamps units (defined in timestamps_specs/).",
-        "scalar"
-    ],
-    "/photon_data/measurement_specs/laser_repetition_rate": [
-        "Repetition rate of the pulsed excitation laser (in Hertz).",
-        "scalar"
-    ],
-    "/photon_data/measurement_specs/alex_offset": [
-        "Time offset (in timestamps unit) to apply to timestamps to obtain a properly aligned alternation histogram.",
-        "scalar"
-    ],
-    "/photon_data/measurement_specs/alex_excitation_period1": [
-        "Values pair (start-stop range, in timestamps units) identifying photons in the excitation period of wavelength 1 (the shortest).",
-        "array"
-    ],
-    "/photon_data/measurement_specs/alex_excitation_period2": [
-        "Values pair (start-stop range, in timestamps units) identifying photons in the excitation period of wavelength 2.",
-        "array"
-    ],
-    "/photon_data/measurement_specs/detectors_specs": [
-        "Mapping between the pixel IDs and the detection channels.",
-        "group"
-    ],
-    "/photon_data/measurement_specs/detectors_specs/spectral_ch1": [
-        "Pixel IDs for the first spectral channel (i.e. donor in a 2-color smFRET measurement).",
-        "array"
-    ],
-    "/photon_data/measurement_specs/detectors_specs/spectral_ch2": [
-        "Pixel IDs for the first spectral channel (i.e. acceptor in a 2-color smFRET measurement).",
-        "array"
-    ],
-    "/photon_data/measurement_specs/detectors_specs/polarization_ch1": [
-        "Pixel IDs for the first polarization channel.",
-        "array"
-    ],
-    "/photon_data/measurement_specs/detectors_specs/polarization_ch2": [
-        "Pixel IDs for the second polarization channel.",
-        "array"
-    ],
-    "/photon_data/measurement_specs/detectors_specs/split_ch1": [
-        "Pixel IDs for the first channel split through a non-polarizing beam splitter.",
-        "array"
-    ],
-    "/photon_data/measurement_specs/detectors_specs/split_ch2": [
-        "Pixel IDs for the second channel split through a non-polarizing beam splitter.",
-        "array"
-    ],
-    "/photon_data/measurement_specs/detectors_specs/labels": [
-        "User defined labels for each pixel IDs. In smFRET it is suggested to use \"donor\" and \"acceptor\" for the respective pixel IDs.",
-        "string"
-    ],
     "/setup": [
         "Information about the experimental setup.",
         "group"
+    ],
+    "/setup/measurement_specs": [
+        "Metadata necessary for interpretation of the particular type of measurement.",
+        "group"
+    ],
+    "/setup/measurement_specs/measurement_type": [
+        "Name of the measurement the data represents.",
+        "string"
+    ],
+    "/setup/measurement_specs/alex_period": [
+        "Period of laser alternation in us-ALEX measurements in timestamps units (defined in timestamps_specs/).",
+        "scalar"
+    ],
+    "/setup/measurement_specs/laser_repetition_rate": [
+        "Repetition rate of the pulsed excitation laser (in Hertz).",
+        "scalar"
+    ],
+    "/setup/measurement_specs/alex_offset": [
+        "Time offset (in timestamps unit) to apply to timestamps to obtain a properly aligned alternation histogram.",
+        "scalar"
+    ],
+    "/setup/measurement_specs/alex_excitation_period1": [
+        "Values pair (start-stop range, in timestamps units) identifying photons in the excitation period of wavelength 1 (the shortest).",
+        "array"
+    ],
+    "/setup/measurement_specs/alex_excitation_period2": [
+        "Values pair (start-stop range, in timestamps units) identifying photons in the excitation period of wavelength 2.",
+        "array"
+    ],
+    "/setup/measurement_specs/detectors_specs": [
+        "Mapping between the pixel IDs and the detection channels.",
+        "group"
+    ],
+    "/setup/measurement_specs/detectors_specs/spectral_ch1": [
+        "Pixel IDs for the first spectral channel (i.e. donor in a 2-color smFRET measurement).",
+        "array"
+    ],
+    "/setup/measurement_specs/detectors_specs/spectral_ch2": [
+        "Pixel IDs for the second spectral channel (i.e. acceptor in a 2-color smFRET measurement).",
+        "array"
+    ],
+    "/setup/measurement_specs/detectors_specs/spectral_ch3": [
+        "Pixel IDs for the third spectral detection channel.",
+        "array"
+    ],
+    "/setup/measurement_specs/detectors_specs/spectral_ch4": [
+        "Pixel IDs for the fourth spectral detection channel.",
+        "array"
+    ],
+    "/setup/measurement_specs/detectors_specs/polarization_ch1": [
+        "Pixel IDs for the first polarization channel.",
+        "array"
+    ],
+    "/setup/measurement_specs/detectors_specs/polarization_ch2": [
+        "Pixel IDs for the second polarization channel.",
+        "array"
+    ],
+    "/setup/measurement_specs/detectors_specs/split_ch1": [
+        "Pixel IDs for the first channel split through a non-polarizing beam splitter.",
+        "array"
+    ],
+    "/setup/measurement_specs/detectors_specs/split_ch2": [
+        "Pixel IDs for the second channel split through a non-polarizing beam splitter.",
+        "array"
+    ],
+    "/setup/measurement_specs/detectors_specs/labels": [
+        "User defined labels for each pixel IDs. In smFRET it is suggested to use \"donor\" and \"acceptor\" for the respective pixel IDs.",
+        "string"
     ],
     "/setup/num_pixels": [
         "Total number of detector pixels.",

--- a/phconvert/specs/photon-hdf5_specs.json
+++ b/phconvert/specs/photon-hdf5_specs.json
@@ -118,7 +118,7 @@
     "/photon_data/measurement_specs/detectors_specs/split_ch2": [
         "Pixel IDs for the second channel split through a non-polarizing beam splitter.",
         "array"
-    ],    
+    ],
     "/setup": [
         "Information about the experimental setup.",
         "group"
@@ -191,11 +191,15 @@
         "Metadata relative to each detector's pixel. Each field is an array with size equal to the number of the detectors.",
         "group"
     ],
-    "/setup/detectors/ids": [
+    "/setup/detectors/id": [
+        "Array of detector IDs as they appear on /photon_data/detectors.",
+        "array"
+    ],
+    "/setup/detectors/id_hardware": [
         "Array of original IDs assigned by the acquisition hardware to each detector.",
         "array"
     ],
-    "/setup/detectors/labels": [
+    "/setup/detectors/label": [
         "Array of labels (strings) describing each detector.",
         "array"
     ],

--- a/phconvert/specs/photon-hdf5_specs.json
+++ b/phconvert/specs/photon-hdf5_specs.json
@@ -143,6 +143,10 @@
         "True (i.e. 1) if there is any form of excitation modulation of excitation wavelength (as in us-ALEX or PAX) or polarization. This field is also True for pulse-interleaved excitation (PIE) or ns-ALEX measurements.",
         "scalar"
     ],
+    "/setup/excitation_alternated": [
+        "New in version 0.5. Indicates whether each excitation source is alternated (True, or 1) or not alternated (False, or 0)."
+        "array"
+    ],
     "/setup/lifetime": [
         "True (i.e. 1) if the measurement includes a nanotimes array of photon arrival times with respect to a laser pulse (as in TCSPC measurements).",
         "scalar"

--- a/phconvert/specs/photon-hdf5_specs.json
+++ b/phconvert/specs/photon-hdf5_specs.json
@@ -192,23 +192,23 @@
         "group"
     ],
     "/setup/detectors/id": [
-        "Array of detector IDs as they appear on /photon_data/detectors.",
+        "Detector IDs as they appear on /photon_data/detectors.",
         "array"
     ],
     "/setup/detectors/id_hardware": [
-        "Array of original IDs assigned by the acquisition hardware to each detector.",
+        "Original IDs assigned by the acquisition hardware to each detector.",
         "array"
     ],
     "/setup/detectors/label": [
-        "Array of labels (strings) describing each detector.",
+        "Labels (strings) describing each detector.",
         "array"
     ],
     "/setup/detectors/counts": [
-        "Array of number photons detected by each detector.",
+        "Total number of counts detected by each detector.",
         "array"
     ],
     "/setup/detectors/module": [
-        "Array of strings containing the module's name for each pixel.",
+        "The module's name each pixel belongs to.",
         "array"
     ],
     "/setup/detectors/position": [
@@ -224,7 +224,7 @@
         "array"
     ],
     "/setup/detectors/spot": [
-        "Spot number where the pixel is used.",
+        "Spot number for each pixel in the measurement.",
         "array"
     ],
     "/setup/detectors/tcspc_units": [

--- a/phconvert/specs/photon-hdf5_specs.json
+++ b/phconvert/specs/photon-hdf5_specs.json
@@ -215,6 +215,18 @@
         "Spot number where the pixel is used.",
         "array"
     ],
+    "/setup/detectors/nanotimes_specs": [
+        "TCSPC specifications for each pixel.",
+        "group"
+    ],
+    "/setup/detectors/nanotimes_specs/tcspc_units": [
+        "TCSPC bin size in seconds (i.e. nanotimes units) for each pixel.",
+        "array"
+    ],
+    "/setup/detectors/nanotimes_specs/tcspc_num_bins": [
+        "Number of TCSPC bins for each pixel.",
+        "array"
+    ],
     "/identity": [
         "Information about the Photon-HDF5 data file.",
         "group"


### PR DESCRIPTION
# Summary

This PR implements saving Photon-HDF5 version 0.5 and will be part of the phconvert 1.0 release.

Specifications for Photon-HDF5 0.5 can be found here:

http://photon-hdf5.readthedocs.io/en/0.5.dev/

# Roadmap

Photon-HDF5 version 0.5 will be a drop-in replacement for the 0.4 version. After merging this PR, phconvert cannot save anymore 0.4 files. To save files Photon-HDF5 0.4 you can use the last version of phconvert < 1.0 (0.7.3 as the time of writing). This legacy version will be in light maintenance-mode meaning that it will only receive critical bug-fixes but no new features. 

All the new development, including supporting conversion and decoding of third party file formats will continue in phconvert 1.x and above.

# What changed in Photon-HDF5 0.5

The main changes are:

1. add of a `generic` measurement type whose configuration is specified by the fields in `/setup`.
1. addition of a mandatory field `/setup/alternated_excitation`, a bool array with one element per laser.  Each element is True if the corresponding laser is intensity-modulated. This allows distinguishing ALEX and PAX.
1. addition of `/setup/detectors` group with extended detectors information

Note that for single-spot measurements no change to the conversion notebooks is required. Phconvert will automatically fill the new `/setup/alternated_excitation` and `/setup/detectors` fields.

# Other feature in this PR

- `save_photon_hdf5` can now save into a pre-existing HDF5 file containing the photon_data arrays to avoid additional copies during conversion of large files.
- support numpy 1.12
