### PR TITLE
Appveyor: activate base env before using conda build.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,6 +65,7 @@ after_test:
   - python setup.py bdist_wheel
   - echo %PATH%
   - conda deactivate
+  - activate
   - path
   - where python
   - where git


### PR DESCRIPTION
See: https://github.com/conda/conda-build/issues/3220