### PR TITLE
Ensure h5file is closed even if validation fails

### DIFF
--- a/phconvert/hdf5.py
+++ b/phconvert/hdf5.py
@@ -397,12 +397,14 @@ def save_photon_hdf5(data_dict,
     h5file.flush()
 
     ## Validation
-    if validate:
-        kwargs = dict(skip_measurement_specs=skip_measurement_specs,
-                      warnings=warnings, require_setup=require_setup)
-        assert_valid_photon_hdf5(h5file, **kwargs)
-    if close:
-        h5file.close()
+    try:
+        if validate:
+            kwargs = dict(skip_measurement_specs=skip_measurement_specs,
+                          warnings=warnings, require_setup=require_setup)
+            assert_valid_photon_hdf5(h5file, **kwargs)
+    finally:
+        if close:
+            h5file.close()
 
 
 def _is_mutispot(h5root_or_dict):


### PR DESCRIPTION
This fixes a bug where if validation of the Photon-HDF5 file failed, then save_photon_hdf5() would not close it even if the user had requested us to do so. This behavior created an awkward situation if the user did not save the file object in a variable somewhere, since they would be unable to close it and thus unable to try saving to it again without restarting the python process. With this fix, save_photon_hdf5() becomes more amenable to experimenting at the console without interrupting the flow of things to restart the process after mistakenly trying to save malformed data.