### PR TITLE
Update hdf5.py to replace depreciated np.asscalar

### DIFF
--- a/phconvert/hdf5.py
+++ b/phconvert/hdf5.py
@@ -791,7 +791,7 @@ def _convert_scalar_item(item):
     if not np.isscalar(item['value']):
         try:
             # sequences are converted to array then to scalar
-            scalar_value = np.asscalar(np.asarray(item['value']))
+            scalar_value = np.asarray(item['value']).item()
         except ValueError:
             raise Invalid_PhotonHDF5('Cannot convert "%s" to scalar.'
                                      % item['meta_path'])


### PR DESCRIPTION
The function _convert_scalar_item contained np.asscalar which was depreciated in NumPy v1.16:
`scalar_value = np.asscalar(np.asarray(item['value']))`
This line has been changed to 
`scalar_value = np.asarray(item['value']).item()`